### PR TITLE
Add line numbers to LLM context

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ python codebase-understanding/main.py --dir /path/to/project
 ```
 
 This process downloads or reads the code, identifies abstractions and relationships, then produces tutorial chapters inside the directory specified by `--output` (default: `./output`).
+All code snippets sent to the LLM include their original line numbers so the generated tutorials can reference specific lines.
 
 
 ### Common options

--- a/codebase-understanding/nodes.py
+++ b/codebase-understanding/nodes.py
@@ -7,16 +7,22 @@ from utils.call_llm import call_llm
 from utils.crawl_local_files import crawl_local_files
 
 
+# Helper to add line numbers to code content
+def add_line_numbers(text: str) -> str:
+    """Prefix each line of text with its line number."""
+    lines = text.splitlines()
+    return "\n".join(f"{i+1:4d}: {line}" for i, line in enumerate(lines))
+
+
 
 # Helper to get content for specific file indices
 def get_content_for_indices(files_data, indices):
+    """Return a mapping of file index/path to numbered content."""
     content_map = {}
     for i in indices:
         if 0 <= i < len(files_data):
             path, content = files_data[i]
-            content_map[f"{i} # {path}"] = (
-
-            )
+            content_map[f"{i} # {path}"] = add_line_numbers(content)
     return content_map
 
 
@@ -95,7 +101,8 @@ class IdentifyAbstractions(Node):
             context = ""
             file_info = []  # Store tuples of (index, path)
             for i, (path, content) in enumerate(files_data):
-
+                numbered = add_line_numbers(content)
+                entry = f"--- File Index {i}: {path} ---\n{numbered}\n\n"
                 context += entry
                 file_info.append((i, path))
 
@@ -141,7 +148,7 @@ class IdentifyAbstractions(Node):
         prompt = f"""
 For the project `{project_name}`:
 
-Codebase Context:
+ Codebase Context (lines prefixed with their numbers):
 {context}
 
 
@@ -267,7 +274,7 @@ class AnalyzeRelationships(Node):
             )  # Use potentially translated name here too
             all_relevant_indices.update(abstr["files"])
 
-        context += "\\nRelevant File Snippets (Referenced by Index and Path):\\n"
+        context += "\\nRelevant File Snippets with line numbers (Referenced by Index and Path):\\n"
         # Get content for relevant files using helper
         relevant_files_content_map = get_content_for_indices(
             files_data, sorted(list(all_relevant_indices))
@@ -314,7 +321,7 @@ Based on the following abstractions and relevant code snippets from the project 
 List of Abstraction Indices and Names{list_lang_note}:
 {abstraction_listing}
 
-Context (Abstractions, Descriptions, Code):
+Context (Abstractions, Descriptions, Code with line numbers):
 {context}
 
 
@@ -692,7 +699,7 @@ Complete Tutorial Structure{structure_note}:
 Context from previous chapters{prev_summary_note}:
 {previous_chapters_summary if previous_chapters_summary else "This is the first chapter."}
 
-Relevant Code Snippets (Code itself remains unchanged):
+ Relevant Code Snippets with line numbers (Code itself remains unchanged):
 {file_context_str if file_context_str else "No specific code snippets provided for this abstraction."}
 
 


### PR DESCRIPTION
## Summary
- fix `create_llm_context` to assemble numbered code blocks
- restore helper for adding line numbers and use it throughout
- document line-number feature in README

## Testing
- `python -m py_compile codebase-understanding/nodes.py`
- `python -m py_compile codebase-understanding/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68532e1c67e083279c16b137f9701305