### PR TITLE
Add token-per-minute limiter for Gemini API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ pip install -r requirements.txt
 ```
 
 3. Provide credentials for your preferred LLM provider. The default implementation expects the `GEMINI_API_KEY` environment variable, but `codebase-understanding/utils/call_llm.py` can be adapted for other providers.
-4. When crawling GitHub repositories, supply a personal access token using `--token` or the `GITHUB_TOKEN` environment variable to avoid rate limits.
+4. Optionally set `GEMINI_TPM_LIMIT` to control the allowed Gemini tokens per minute (default: `200000`).
+5. When crawling GitHub repositories, supply a personal access token using `--token` or the `GITHUB_TOKEN` environment variable to avoid rate limits.
 
 ## Running the codebase-understanding flow
 

--- a/codebase-understanding/nodes.py
+++ b/codebase-understanding/nodes.py
@@ -7,6 +7,13 @@ from utils.call_llm import call_llm
 from utils.crawl_local_files import crawl_local_files
 
 
+# Helper to add line numbers to code content
+def add_line_numbers(text: str) -> str:
+    """Prefix each line of text with its line number."""
+    lines = text.splitlines()
+    return "\n".join(f"{i+1:4d}: {line}" for i, line in enumerate(lines))
+
+
 
 # Helper to get content for specific file indices
 def get_content_for_indices(files_data, indices):
@@ -97,7 +104,8 @@ class IdentifyAbstractions(Node):
             context = ""
             file_info = []  # Store tuples of (index, path)
             for i, (path, content) in enumerate(files_data):
-
+                numbered = add_line_numbers(content)
+                entry = f"--- File Index {i}: {path} ---\n{numbered}\n\n"
                 context += entry
                 file_info.append((i, path))
 

--- a/codebase-understanding/utils/call_llm.py
+++ b/codebase-understanding/utils/call_llm.py
@@ -3,6 +3,8 @@ import os
 import logging
 import json
 from datetime import datetime
+import time
+from threading import Lock
 
 # Configure logging
 log_directory = os.getenv("LOG_DIR", "logs")
@@ -24,11 +26,61 @@ logger.addHandler(file_handler)
 # Simple cache configuration
 cache_file = "llm_cache.json"
 
+# Token bucket for Gemini token-per-minute rate limiting
+TPM_LIMIT = int(os.getenv("GEMINI_TPM_LIMIT", "200000"))
+_tokens = TPM_LIMIT
+_last_check = time.monotonic()
+_bucket_lock = Lock()
+
+
+def _refill_tokens():
+    """Refill tokens in the bucket based on elapsed time."""
+    global _tokens, _last_check
+    now = time.monotonic()
+    elapsed = now - _last_check
+    if elapsed <= 0:
+        return
+    rate_per_sec = TPM_LIMIT / 60
+    _tokens = min(TPM_LIMIT, _tokens + elapsed * rate_per_sec)
+    _last_check = now
+
+
+def _acquire_tokens(tokens_needed: float) -> None:
+    """Block until the requested number of tokens is available."""
+    global _tokens
+
+    # Never require more than the bucket can hold in a single wait cycle
+    tokens_needed = min(tokens_needed, TPM_LIMIT)
+    rate_per_sec = TPM_LIMIT / 60
+
+    while True:
+        with _bucket_lock:
+            _refill_tokens()
+            if tokens_needed <= _tokens:
+                _tokens -= tokens_needed
+                return
+            missing = tokens_needed - _tokens
+
+        sleep_time = max(missing / rate_per_sec, 0)
+        if sleep_time > 0:
+            time.sleep(sleep_time)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Very rough token estimate using 4 characters per token."""
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
 
 # By default, we Google Gemini 2.5 pro, as it shows great performance for code understanding
 def call_llm(prompt: str, use_cache: bool = True) -> str:
+    """Call Gemini with optional caching and token-per-minute limiting."""
     # Log the prompt
     logger.info(f"PROMPT: {prompt}")
+
+    # Throttle based on token usage of the prompt
+    _acquire_tokens(_estimate_tokens(prompt))
 
     # Check cache if enabled
     if use_cache:
@@ -61,6 +113,8 @@ def call_llm(prompt: str, use_cache: bool = True) -> str:
     
     response = client.models.generate_content(model=model, contents=[prompt])
     response_text = response.text
+    # Account for tokens used by the response
+    _acquire_tokens(_estimate_tokens(response_text))
 
     # Log the response
     logger.info(f"RESPONSE: {response_text}")


### PR DESCRIPTION
## Summary
- implement a simple token bucket in `call_llm` to throttle Gemini requests
- document optional `GEMINI_TPM_LIMIT` variable in the README
- handle requests larger than the bucket size so the rate limiter doesn't hang

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533cc24ea48327ab86699903b09619